### PR TITLE
Start bash at login instead of zsh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,4 @@ USER peitsier
 ENV HOME /home/peitsier
 RUN cp /etc/zsh/newuser.zshrc.recommended /home/peitsier/.zshrc
 WORKDIR /mydata
-CMD ["zsh"]
-
+CMD ["bash"]


### PR DESCRIPTION
As much as I like zsh, having the image starting zsh on Myriad is a pain and prevents a fully non-interactive session.  If the user really wants to switch to zsh, that's just three keys (and a Return) away.